### PR TITLE
Check if scrambled before showing solve message

### DIFF
--- a/MagicCube5D/workFiles/cube5D.cpp
+++ b/MagicCube5D/workFiles/cube5D.cpp
@@ -575,14 +575,14 @@ CCube5D::save( bool saveas )
 {
 	StateMatrix state;
 	m_transformer.stickersToMatrix( m_stickers, state );
-	m_loader.saveToFile( state, m_twists, saveas );
+	m_loader.saveToFile( state, m_twists, saveas, m_scrambled );
 }
 
 void 
 CCube5D::load() 
 {
 	StateMatrix state;
-	if( !m_loader.loadFromFile( state, m_twists ) )
+	if( !m_loader.loadFromFile( state, m_twists, &m_scrambled ) )
 		return;
 
 	// Use the loaded state to determine our puzzle type.

--- a/MagicCube5D/workFiles/cube5D.cpp
+++ b/MagicCube5D/workFiles/cube5D.cpp
@@ -14,6 +14,7 @@ CCube5D::CCube5D() : m_transformer( m_settings )
 	m_solvedMessageShown = false;
 	m_currentlyRecording = false;
 	m_useStereoColor = false;
+	m_scrambled = false;
 
 	// Setup default settings.
 	m_settings.setAllVisible();
@@ -687,6 +688,8 @@ CCube5D::selectStickerHelper( const CVector3D & linep1, const CVector3D & linep2
 void 
 CCube5D::scramble( int numTwists ) 
 {
+	m_scrambled = numTwists >= 100;
+
 	// XXX - a little hackish, since I'm checking a hardcoded value of a full scramble
 	if( m_settings.m_n > 5 && 100 == numTwists )
 		numTwists *= 2;
@@ -785,6 +788,10 @@ CCube5D::isSolved() const
 bool 
 CCube5D::showSolvedMessage()
 {
+	// We only want to show the message if an actual scramble occurred.
+	if ( !m_scrambled )
+		return false;
+
 	// We only want to show a message once.
 	if( m_solvedMessageShown )
 		return false;

--- a/MagicCube5D/workFiles/cube5D.h
+++ b/MagicCube5D/workFiles/cube5D.h
@@ -230,6 +230,9 @@ private:
 
 	// Solved info.
 	SSolvedInfo m_solvedInfo;
+
+	// Whether or not a full scramble occurred.
+	bool m_scrambled;
 };
 
 #pragma managed(pop)

--- a/MagicCube5D/workFiles/loader.cpp
+++ b/MagicCube5D/workFiles/loader.cpp
@@ -15,7 +15,7 @@ CLoader::CLoader()
 }
 
 void 
-CLoader::saveToFile( const StateMatrix & state, const std::vector<STwist> & twists, bool saveas ) 
+CLoader::saveToFile( const StateMatrix & state, const std::vector<STwist> & twists, bool saveas, bool scrambled ) 
 {
 	// Get the filename to save to.
 	String ^ fileName = getSaveFileName( saveas );
@@ -26,6 +26,11 @@ CLoader::saveToFile( const StateMatrix & state, const std::vector<STwist> & twis
 
 	// Write the header.
 	String ^ header = "MagicCube5D\t" + VERSION_STRING + "\t" + System::Convert::ToString( twists.size() );
+
+	// Append a simple "s" if the cube has been scrambled.
+	if (scrambled)
+		header += "\ts";
+
 	sw->WriteLine( header );
 
 	// Now write out the state.
@@ -46,7 +51,7 @@ CLoader::saveToFile( const StateMatrix & state, const std::vector<STwist> & twis
 }
 
 bool 
-CLoader::loadFromFile( StateMatrix & state, std::vector<STwist> & twists ) 
+CLoader::loadFromFile( StateMatrix & state, std::vector<STwist> & twists, bool * scrambled ) 
 {
 	String ^ fileName = getLoadFileName();
 	if( ! File::Exists( fileName ) )
@@ -76,6 +81,9 @@ CLoader::loadFromFile( StateMatrix & state, std::vector<STwist> & twists )
 	myEnum->MoveNext();
 	tempString = safe_cast<String ^>( myEnum->Current );
 	int numTwists = System::Convert::ToInt32( tempString );
+
+	if (scrambled != NULL)
+		*scrambled = split->Length >= 4 && split[3]->Equals("s");
 
 	// Now read the state.
 	state.resize( 10 );

--- a/MagicCube5D/workFiles/loader.h
+++ b/MagicCube5D/workFiles/loader.h
@@ -10,8 +10,8 @@ public:
 	CLoader();
 
 	// Save/Load the entire puzzle.
-	void saveToFile( const StateMatrix & state, const std::vector<STwist> & twists, bool saveas );
-	bool loadFromFile( StateMatrix & state, std::vector<STwist> & twists );
+	void saveToFile( const StateMatrix & state, const std::vector<STwist> & twists, bool saveas, bool scrambled = false );
+	bool loadFromFile( StateMatrix & state, std::vector<STwist> & twists, bool * scrambled = NULL );
 
 	// Save/Load macros.
 	void saveMacrosToFile( const std::vector<SMacro> & macros );


### PR DESCRIPTION
* Add member `m_scrambled` to `CCube5D` which is set if a scramble of
  over 100 moves has occurred.
* Update `CCube5D::showSolvedMessage()` to check if `m_scrambled` is
  set. If not, the message will not be shown.

Fixes Issue #1.